### PR TITLE
Fix block drops being wrong for last hit with a breaking tool

### DIFF
--- a/src/main/java/betterwithmods/common/registry/BrokenToolRegistry.java
+++ b/src/main/java/betterwithmods/common/registry/BrokenToolRegistry.java
@@ -1,0 +1,68 @@
+package betterwithmods.common.registry;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * HCLumber and HCPiles try to give appropriate output if the appropriate tool is used
+ * They do this by checking the tool in your main hand on HarvestDropsEvent.
+ * Unfortunately by the time HarvestDropsEvent occurs, the "appropriate tool" has been destroyed.
+ *
+ * This registry keeps track of the last destroyed item in each player's main hand until the next server tick.
+ * HCLumber and HCPiles have been modified accordingly to check this registry if the main hand appears empty.
+ *
+ * It tries to be efficient about it by only registering for a tick event as needed.
+ */
+public class BrokenToolRegistry
+{
+
+    public static final Map<UUID, ItemStack> destroyed = new HashMap<>();
+    private static final Ticker ticker = new Ticker();
+
+    public static void init()
+    {
+        MinecraftForge.EVENT_BUS.register(BrokenToolRegistry.class);
+    }
+
+    public static ItemStack getDestroyedItem(EntityPlayer player)
+    {
+        return destroyed.getOrDefault(player.getUniqueID(), ItemStack.EMPTY);
+    }
+
+    @SubscribeEvent
+    public static void onPlayerDestroyItem(PlayerDestroyItemEvent event)
+    {
+        EntityPlayer player = event.getEntityPlayer();
+        if (player == null || player.getEntityWorld().isRemote || event.getHand() != EnumHand.MAIN_HAND) {
+            return;
+        }
+        ItemStack item = event.getOriginal();
+        if (item.isEmpty()) {
+            return;
+        }
+        destroyed.put(player.getUniqueID(), item);
+        MinecraftForge.EVENT_BUS.register(ticker);
+    }
+
+    public static class Ticker
+    {
+
+        @SubscribeEvent
+        public void onTick(TickEvent.ServerTickEvent event)
+        {
+            destroyed.clear();
+            MinecraftForge.EVENT_BUS.unregister(this);
+        }
+
+    }
+
+}

--- a/src/main/java/betterwithmods/module/hardcore/crafting/HCLumber.java
+++ b/src/main/java/betterwithmods/module/hardcore/crafting/HCLumber.java
@@ -2,6 +2,7 @@ package betterwithmods.module.hardcore.crafting;
 
 import betterwithmods.common.BWMRecipes;
 import betterwithmods.common.BWOreDictionary;
+import betterwithmods.common.registry.BrokenToolRegistry;
 import betterwithmods.common.registry.ChoppingRecipe;
 import betterwithmods.module.Feature;
 import betterwithmods.util.InvUtils;
@@ -31,7 +32,12 @@ public class HCLumber extends Feature {
             EntityPlayer player = event.getHarvester();
             if (player != null) {
                 ItemStack stack = player.getItemStackFromSlot(EntityEquipmentSlot.MAINHAND);
-                return stack.getItem().getHarvestLevel(player.getItemStackFromSlot(EntityEquipmentSlot.MAINHAND), "axe", player, event.getState()) >= 0 || stack.getItem().getToolClasses(player.getItemStackFromSlot(EntityEquipmentSlot.MAINHAND)).contains("axe");
+                if (stack.isEmpty()) {
+                    // if the tool broke while harvesting this block...
+                    // it's not in the main hand anymore by the time HarvestDropsEvent happens
+                    stack = BrokenToolRegistry.getDestroyedItem(player);
+                }
+                return stack.getItem().getHarvestLevel(stack, "axe", player, event.getState()) >= 0 || stack.getItem().getToolClasses(stack).contains("axe");
             }
         }
         return event.isSilkTouching();
@@ -55,7 +61,7 @@ public class HCLumber extends Feature {
 
     @Override
     public void init(FMLInitializationEvent event) {
-
+        BrokenToolRegistry.init();
     }
 
     @Override

--- a/src/main/java/betterwithmods/module/hardcore/needs/HCPiles.java
+++ b/src/main/java/betterwithmods/module/hardcore/needs/HCPiles.java
@@ -2,6 +2,7 @@ package betterwithmods.module.hardcore.needs;
 
 import betterwithmods.common.BWMBlocks;
 import betterwithmods.common.BWMItems;
+import betterwithmods.common.registry.BrokenToolRegistry;
 import betterwithmods.module.Feature;
 import betterwithmods.util.player.PlayerHelper;
 import net.minecraft.block.Block;
@@ -47,6 +48,7 @@ public class HCPiles extends Feature {
 
     @Override
     public void init(FMLInitializationEvent event) {
+        BrokenToolRegistry.init();
         registerPile(Blocks.DIRT, new ItemStack(BWMItems.DIRT_PILE, 3));
         registerPile(Blocks.DIRT, 1, new ItemStack(BWMItems.DIRT_PILE, 3));
         registerPile(Blocks.DIRT, 2, new ItemStack(BWMItems.DIRT_PILE, 3));
@@ -87,6 +89,11 @@ public class HCPiles extends Feature {
         EntityPlayer player = event.getHarvester();
         if (player != null) {
             ItemStack stack = event.getHarvester().getHeldItemMainhand();
+            if (stack.isEmpty()) {
+                // if the tool broke while harvesting this block...
+                // it's not in the main hand anymore by the time HarvestDropsEvent happens
+                stack = BrokenToolRegistry.getDestroyedItem(player);
+            }
             if (PlayerHelper.isCurrentToolEffectiveOnBlock(stack, event.getState()))
                 return;
         }


### PR DESCRIPTION
I tried adjusting the wooden shovel max damage to be a bit more useful and noticed something felt odd...

With HCLumber and HCPiles, the last hit with an effective tool drops "crappy" drops (e.g. piles or planks + sawdust) even when the correct tool is used.

This happens because the tool's item stack is empty by the time the block harvest event fires.

This pull request addresses the above issue.

It's not ideal... I didn't know where to put it since it's shared between two modules than can be turned on and off independently.

I welcome any pointers for how this could be done better.