### PR TITLE
Add config option for default furnace smelting time

### DIFF
--- a/src/main/java/betterwithmods/common/blocks/tile/TileFurnace.java
+++ b/src/main/java/betterwithmods/common/blocks/tile/TileFurnace.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public class TileFurnace extends TileEntityFurnace {
     @Override
     public int getCookTime(ItemStack stack) {
-        return HCFurnace.FURNACE_TIMINGS.entrySet().stream().filter(e -> e.getKey().apply(stack)).mapToInt(Map.Entry::getValue).findAny().orElse(200);
+        return HCFurnace.FURNACE_TIMINGS.entrySet().stream().filter(e -> e.getKey().apply(stack)).mapToInt(Map.Entry::getValue).findAny().orElse(HCFurnace.DEFAULT_FURNACE_TIMING);
     }
 
     public void update()

--- a/src/main/java/betterwithmods/module/hardcore/crafting/HCFurnace.java
+++ b/src/main/java/betterwithmods/module/hardcore/crafting/HCFurnace.java
@@ -21,11 +21,17 @@ public class HCFurnace extends Feature {
         enabledByDefault = false;
     }
 
+    public static int DEFAULT_FURNACE_TIMING = 200;
     public static HashMap<Ingredient, Integer> FURNACE_TIMINGS = Maps.newHashMap();
 
     public static final Block FURNACE = new BlockFurnace(false).setRegistryName("minecraft:furnace");
     public static final Block LIT_FURNACE = new BlockFurnace(true).setRegistryName("minecraft:lit_furnace");
 
+    @Override
+    public void setupConfig()
+    {
+        DEFAULT_FURNACE_TIMING = loadPropInt("Default Furnace Timing", "Default number of ticks for an item to smelt in the furnace (vanilla is 200)", "", 200, 1, Integer.MAX_VALUE);
+    }
 
     @Override
     public void preInit(FMLPreInitializationEvent event) {


### PR DESCRIPTION
With HCFurnace (which is amazing BTW)... the default smelting time is hard-coded to the vanilla value of 200.

This pull request makes it configurable in case some crazy masochist wants to make everything take longer to smelt without defining a custom timing for every potential item.

As a side note, I noticed some features define configuration in `postInit()` instead of `setupConfig()`, which prevents such items from appearing in the config file unless the value is modified via the Forge config GUI. I can make a separate pull request to move these items to `setupConfig()` if you'd like.