### PR TITLE
Fix IE hemp seeds not being blacklisted from hoe drops

### DIFF
--- a/src/main/java/betterwithmods/module/compat/immersiveengineering/ImmersiveEngineering.java
+++ b/src/main/java/betterwithmods/module/compat/immersiveengineering/ImmersiveEngineering.java
@@ -4,7 +4,7 @@ import betterwithmods.module.CompatFeature;
 import betterwithmods.module.hardcore.needs.HCSeeds;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
 /**
@@ -21,7 +21,7 @@ public class ImmersiveEngineering extends CompatFeature {
     public static final Item HEMP_SEED = null;
 
     @Override
-    public void preInit(FMLPreInitializationEvent event) {
+    public void init(FMLInitializationEvent event) {
         HCSeeds.SEED_BLACKLIST.add(new ItemStack(HEMP_SEED));
     }
 }


### PR DESCRIPTION
As per title, as Forge object holders aren't yet injected on preInit.