### PR TITLE
Fix crash without Rustic present

### DIFF
--- a/src/main/java/betterwithmods/module/ConfigHelper.java
+++ b/src/main/java/betterwithmods/module/ConfigHelper.java
@@ -46,7 +46,7 @@ public class ConfigHelper {
         @Override
         public BooleanSupplier parse(JsonContext context, JsonObject json) {
             String enabled = JsonUtils.getString(json, "enabled");
-            return () -> CONDITIONS.get(enabled);
+            return () -> CONDITIONS.getOrDefault(enabled, false);
         }
     }
 


### PR DESCRIPTION
If Rustic isn't enabled, the latest 1.12 branch crashes because the enabled condition for it doesn't exist.

I realize this will likely be fixed more comprehensively in #714, but this is a simple fix for now.