### PR TITLE
Don't set fuel burn time if no timing is defined for it

### DIFF
--- a/src/main/java/betterwithmods/module/hardcore/crafting/HCFurnace.java
+++ b/src/main/java/betterwithmods/module/hardcore/crafting/HCFurnace.java
@@ -130,8 +130,10 @@ public class HCFurnace extends Feature {
 
     @SubscribeEvent
     public void getFurnaceFuel(FurnaceFuelBurnTimeEvent event) {
-        int speed = FUEL_TIMINGS.entrySet().stream().filter(e -> e.getKey().apply(event.getItemStack())).mapToInt(Map.Entry::getValue).findAny().orElse(event.getBurnTime());
-        event.setBurnTime(speed);
+        int speed = FUEL_TIMINGS.entrySet().stream().filter(e -> e.getKey().apply(event.getItemStack())).mapToInt(Map.Entry::getValue).findAny().orElse(-1);
+        if (speed >= 0) {
+            event.setBurnTime(speed);
+        }
     }
 
 


### PR DESCRIPTION
Please consider accepting this as setBurnTime() also cancels the event, so if you don't have a furnace fuel configured, you probably shouldn't call setBurnTime() at all.